### PR TITLE
Add Fullstack openings and align all FE/BE/FS engineering positions

### DIFF
--- a/openings/backend-developer.md
+++ b/openings/backend-developer.md
@@ -4,7 +4,7 @@
 
 ## The role
 
-We are hiring backend engineers who embrace software craftsmanship and have a strong background in software
+We are hiring a **Backend Developer** who embraces software craftsmanship and has a strong background in software
 development.
 
 Our main product work happens inside cross-disciplinary teams, that we call squads. Each squad is responsible for
@@ -13,7 +13,7 @@ features can be related to one (or more) of our verticals: Accounting, Invoicing
 Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
 performance of the product, creating a safe and fair experience for all our clients.
 
-Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/).
 
 ## The team
 
@@ -29,10 +29,9 @@ areas of the business.
 - You will design domain-driven systems combining strategic and tactical design (DDD).
 - You will practice DevOps, you will help to maintain the infrastructure and development environments needed for your
   product area.
-- When you have developed something, you will know how to (and you will want to) deploy it to a production environment
-- As a developer, you will mentor other team members, and they will have you as a reference and someone to learn
-  from.
-- You will lead architectural decisions, communicates them, and help teams to adopt the decisions.
+- When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
+- As a developer, you will help other team members grow, sharing what you know and learning from them.
+- You will contribute to architectural decisions, communicate them, and help teams to adopt them.
 - You will collaborate with hiring and training technical personnel.
 
 ### In one month
@@ -60,26 +59,27 @@ areas of the business.
 
 ## About you
 
-- You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems
+- You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems.
 - You have a solid software development background, you are familiar with modern and scalable software development
-  practices
-- You care about best practices and software maintainability is a top priority for you
-- You feel comfortable working with data structures and algorithms
-- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc..
-- You like to explore new technologies and are curious about how things work
-- You have mastered at least a higher-level programming language and its ecosystem (ideally PHP, Golang, etc...)
-- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members
+  practices.
+- You have mastered at least a higher-level programming language and its ecosystem (ideally PHP, Golang, etc...).
+- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc...
+- You have testing experience (Unit and Integration at least).
+- You care about best practices and software maintainability is a top priority for you.
+- You feel comfortable working with data structures and algorithms.
+- You like to explore new technologies and are curious about how things work.
+- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
 
 ## Nice-to-haves
 
 - You practice DevOps, you have experience with infrastructure management, Docker, etc...
-- You have experience designing public APIs (REST, gRPC, etc... )
-- You have experience with Javascript and modern frontend development technologies
+- You have experience designing public APIs (REST, gRPC, etc... ).
+- You have experience with Javascript and modern frontend development technologies.
 - But the most important is, you are a freak like we are, you love what you do and you want to enjoy your work while
-  building something important
+  building something important.
 
 [Apply now!](https://jobs.holded.com/o/backend-dev)
 
 <p align="center">
-  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/senior-backend-developer-product.png?id=senior-backend-developer-product.md" title="logo">
+  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/backend-developer.png?id=backend-developer.md" title="logo">
 </p>

--- a/openings/frontend-engineer.md
+++ b/openings/frontend-engineer.md
@@ -4,9 +4,15 @@
 
 ## The role
 
-We are hiring a **Front-end engineer** who embraces software craftsmanship and has a strong background in frontend development.
+We are hiring a **Frontend Engineer** who embraces software craftsmanship and has a strong background in frontend development.
 
-Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+Our main product work happens inside cross-disciplinary teams, that we call squads. Each squad is responsible for
+designing, developing, and operating all services relating to the assigned features, inside the Holded platform. The
+features can be related to one (or more) of our verticals: Accounting, Invoicing, Team Management, Project Management,
+Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
+performance of the product, creating a safe and fair experience for all our clients.
+
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/).
 
 ## The team
 
@@ -16,14 +22,13 @@ full-stack developers, product owners, etc... building and epic digital product.
 The teams are empowered to make independent decisions, partnering effectively with the product, analytics, and other
 areas of the business.
 
-
 ## What you will do
 
 - You will be hands-on writing clean and maintainable code.
-- When you have developed something, you will know how to (and you will want to) deploy it to a production environment
-- As a developer, you will mentor other team members, and they will have you as a reference and someone to learn
-  from.
-- You will lead architectural decisions, communicates them, and help teams to adopt the decisions.
+- You will implement scalable, performant, and accessible web applications that meet user needs.
+- When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
+- As a developer, you will help other team members grow, sharing what you know and learning from them.
+- You will contribute to architectural decisions, communicate them, and help teams to adopt them.
 
 ### In one month
 
@@ -50,25 +55,26 @@ areas of the business.
 
 ## About you
 
-- You have strong JavaScript programming skills (+5 years at least)
-- You have experience with React and Typescript (+3 years at least)
-- You can build custom tooling or libs
-- You have testing experience (Unit and Integration at least)
-- You have excellent verbal and written communication skills, a great teammate with strong analytical, problem solving, debugging, and troubleshooting skills
-- You care about best practices and software maintainability is a top priority for you
-- You feel comfortable working with data structures and algorithms
-- You like to explore new technologies and are curious about how things work
-- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members
+- You have strong JavaScript programming skills.
+- You have solid experience with React and Typescript.
+- You can build custom tooling or libs.
+- You have testing experience (Unit and Integration at least).
+- You have excellent verbal and written communication skills, a great teammate with strong analytical, problem solving, debugging, and troubleshooting skills.
+- You care about best practices and software maintainability is a top priority for you.
+- You feel comfortable working with data structures and algorithms.
+- You like to explore new technologies and are curious about how things work.
+- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
 
 ## Nice-to-haves
-- You have experience with Node.js
-- You have experience with other languages (PHP, GO, ..)
+
+- You have experience with Node.js.
+- You have experience with other languages (PHP, GO, ..).
 - But the most important is, you are a freak like we are, you love what you do and you want to enjoy your work while
-  building something important
+  building something important.
 
 
 [Apply now!](https://jobs.holded.com/o/frontend-engineer/c/new)
 
 <p align="center">
-  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/tech-lead.png?id=tech-lead.md" title="logo">
+  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/frontend-engineer.png?id=frontend-engineer.md" title="logo">
 </p>

--- a/openings/fullstack-engineer.md
+++ b/openings/fullstack-engineer.md
@@ -1,0 +1,90 @@
+# Fullstack Engineer
+
+[Apply now!](https://jobs.holded.com/o/fullstack-engineer)
+
+## The role
+
+We are hiring a **Fullstack Engineer** with a strong backend foundation and a genuine passion for AI. You will own
+features end-to-end, but you will excel on the server side: architecture, data, performance, and reliability. You will
+also bring hands-on experience with AI tools that are reshaping how software is built today.
+
+Our main product work happens inside cross-disciplinary teams, that we call squads. Each squad is responsible for
+designing, developing, and operating all services relating to the assigned features, inside the Holded platform. The
+features can be related to one (or more) of our verticals: Accounting, Invoicing, Team Management, Project Management,
+Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
+performance of the product, creating a safe and fair experience for all our clients.
+
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+
+## The team
+
+You will be part of a product development cross-functional team, where you will work with other backend, frontend and
+full-stack developers, product owners, etc... building and epic digital product.
+
+The teams are empowered to make independent decisions, partnering effectively with the product, analytics, and other
+areas of the business.
+
+## What you will do
+
+- You will be hands-on writing clean and maintainable code across the stack, with a primary focus on the backend.
+- You will design scalable, performant and reliable services and APIs.
+- You will integrate and experiment with AI capabilities (LLMs and AI-assisted features) as part of the product.
+- You will practice DevOps, you will help to maintain the infrastructure and development environments needed for your
+  product area.
+- When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
+- As a developer, you will mentor other team members, and they will have you as a reference and someone to learn
+  from.
+- You will participate in architectural decisions, communicate them, and help teams to adopt them.
+- You will collaborate with hiring and training technical personnel.
+
+### In one month
+
+- You will have completed your onboarding.
+- You will already know the whole team.
+- You will have deployed several times to production.
+- You will have joined the main architectural discussions that will be taking place and have actively participated in
+  them.
+- You will know the main product areas of your squad, and you already know how to ask when you have any product-related
+  question.
+
+### In three months
+
+- You will already know all the processes and tools in depth.
+- You will know the architecture in detail, and you will be in the process of improving certain parts. By then, you will
+  have clear areas you would like to improve and lead the adoption of those improvements.
+- You will have participated in a successful project, be it a product feature, a technical debt reduction, a DX
+  improvement, etc... achieving the expected result and with total technical independence.
+
+### In six months
+
+- You will have become a reference within the team, specially in the squad product areas.
+- Your collaborations and your work will have helped to greatly improve the product and team the development experience.
+
+## About you
+
+- You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems.
+- You have a solid backend development background, with strong PHP skills and knowledge of its modern ecosystem.
+- You actively use AI tooling (Claude Code, LLMs, or similar) as a natural part of your engineering workflow.
+- You have experience with React and Typescript on the frontend side.
+- You care about best practices and software maintainability is a top priority for you.
+- You feel comfortable working with data structures and algorithms.
+- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc..
+- You have experience using design patterns like DDD.
+- You have testing experience (Unit and Integration at least).
+- You like to explore new technologies and are curious about how things work.
+- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
+
+## Nice-to-haves
+
+- You have experience integrating AI/ML APIs or LLMs into production systems.
+- You have experience with vector databases or RAG architectures.
+- You practice DevOps, you have experience with infrastructure management, Docker, etc...
+- You have experience designing public APIs (REST, gRPC, etc... ).
+- But the most important is, you are a freak like we are, you love what you do and you want to enjoy your work while
+  building something important.
+
+[Apply now!](https://jobs.holded.com/o/fullstack-engineer)
+
+<p align="center">
+  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/fullstack-engineer.png?id=fullstack-engineer.md" title="logo">
+</p>

--- a/openings/fullstack-engineer.md
+++ b/openings/fullstack-engineer.md
@@ -14,7 +14,7 @@ features can be related to one (or more) of our verticals: Accounting, Invoicing
 Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
 performance of the product, creating a safe and fair experience for all our clients.
 
-Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/).
 
 ## The team
 
@@ -27,14 +27,14 @@ areas of the business.
 ## What you will do
 
 - You will be hands-on writing clean and maintainable code across the stack, with a primary focus on the backend.
+- You will design domain-driven systems combining strategic and tactical design (DDD).
 - You will design scalable, performant and reliable services and APIs.
 - You will integrate and experiment with AI capabilities (LLMs and AI-assisted features) as part of the product.
 - You will practice DevOps, you will help to maintain the infrastructure and development environments needed for your
   product area.
 - When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
-- As a developer, you will mentor other team members, and they will have you as a reference and someone to learn
-  from.
-- You will participate in architectural decisions, communicate them, and help teams to adopt them.
+- As a developer, you will help other team members grow, sharing what you know and learning from them.
+- You will contribute to architectural decisions, communicate them, and help teams to adopt them.
 - You will collaborate with hiring and training technical personnel.
 
 ### In one month
@@ -66,11 +66,11 @@ areas of the business.
 - You have a solid backend development background, with strong PHP skills and knowledge of its modern ecosystem.
 - You actively use AI tooling (Claude Code, LLMs, or similar) as a natural part of your engineering workflow.
 - You have experience with React and Typescript on the frontend side.
+- You have experience using design patterns like DDD.
+- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc...
+- You have testing experience (Unit and Integration at least).
 - You care about best practices and software maintainability is a top priority for you.
 - You feel comfortable working with data structures and algorithms.
-- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc..
-- You have experience using design patterns like DDD.
-- You have testing experience (Unit and Integration at least).
 - You like to explore new technologies and are curious about how things work.
 - You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
 

--- a/openings/senior-backend-developer-product.md
+++ b/openings/senior-backend-developer-product.md
@@ -4,8 +4,10 @@
 
 ## The role
 
-We are hiring senior backend engineers who embrace software craftsmanship and have a strong background in software
-development.
+We are hiring a **Senior Backend Engineer** who embraces software craftsmanship and has a deep background in software
+development. As a Senior Backend Engineer, you will play a key role in shaping the architecture of our platform,
+influencing scalability and reliability across the company and directly contributing to our mission of building the
+most innovative digital solutions in the industry.
 
 Our main product work happens inside cross-disciplinary teams, that we call squads. Each squad is responsible for
 designing, developing, and operating all services relating to the assigned features, inside the Holded platform. The
@@ -13,7 +15,7 @@ features can be related to one (or more) of our verticals: Accounting, Invoicing
 Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
 performance of the product, creating a safe and fair experience for all our clients.
 
-Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/).
 
 ## The team
 
@@ -29,10 +31,10 @@ areas of the business.
 - You will design domain-driven systems combining strategic and tactical design (DDD).
 - You will practice DevOps, you will help to maintain the infrastructure and development environments needed for your
   product area.
-- When you have developed something, you will know how to (and you will want to) deploy it to a production environment
+- When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
 - As a senior developer, you will mentor other team members, and they will have you as a reference and someone to learn
   from.
-- You will lead architectural decisions, communicates them, and help teams to adopt the decisions.
+- You will lead architectural decisions, communicate them, and help teams to adopt them.
 - You will collaborate with hiring and training technical personnel.
 
 ### In one month
@@ -57,26 +59,32 @@ areas of the business.
 
 - You will have become a reference within the team, specially in the squad product areas.
 - Your collaborations and your work will have helped to greatly improve the product and team the development experience.
+- You will take initiative in learning about our product, understanding real-world cases, building them into our product, and delivering value to our users.
 
 ## About you
 
-- You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems
-- You have a solid software development background, you are familiar with modern and scalable software development
-  practices
-- You care about best practices and software maintainability is a top priority for you
-- You feel comfortable working with data structures and algorithms
-- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc..
-- You like to explore new technologies and are curious about how things work
-- You have mastered at least a higher-level programming language and its ecosystem (ideally PHP, Golang, etc...)
-- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members
+- You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems.
+- You have a deep software development background, you are familiar with modern and scalable software development
+  practices.
+- You have mastered at least a higher-level programming language and its ecosystem (ideally PHP, Golang, etc...).
+- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc...
+- You have testing experience (Unit and Integration at least).
+- You have excellent verbal and written communication skills, a great teammate with strong analytical, problem solving,
+  debugging, and troubleshooting skills.
+- You care about best practices and software maintainability is a top priority for you.
+- You feel comfortable working with data structures and algorithms.
+- You like to explore new technologies and are curious about how things work.
+- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
+- You are proactive and enjoy taking ownership of complex challenges, driving them to resolution.
 
 ## Nice-to-haves
 
+- You have experience using design patterns like DDD at scale.
 - You practice DevOps, you have experience with infrastructure management, Docker, etc...
-- You have experience designing public APIs (REST, gRPC, etc... )
-- You have experience with Javascript and modern frontend development technologies
+- You have experience designing public APIs (REST, gRPC, etc... ).
+- You have experience with Javascript and modern frontend development technologies.
 - But the most important is, you are a freak like we are, you love what you do and you want to enjoy your work while
-  building something important
+  building something important.
 
 [Apply now!](https://jobs.holded.com/o/senior-backend-developer-product/c/new)
 

--- a/openings/senior-frontend-engineer.md
+++ b/openings/senior-frontend-engineer.md
@@ -4,10 +4,16 @@
 
 ## The role
 
-We are hiring a **Senior Frontend engineer** who embraces software craftsmanship and has a strong background in frontend development. 
+We are hiring a **Senior Frontend Engineer** who embraces software craftsmanship and has a deep background in frontend development.
 As a Senior Frontend Engineer, you will play a key role in shaping the user experience of our platform, influencing several users and directly contributing to our mission of building the most innovative digital solutions in the industry.
 
-Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+Our main product work happens inside cross-disciplinary teams, that we call squads. Each squad is responsible for
+designing, developing, and operating all services relating to the assigned features, inside the Holded platform. The
+features can be related to one (or more) of our verticals: Accounting, Invoicing, Team Management, Project Management,
+Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
+performance of the product, creating a safe and fair experience for all our clients.
+
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/).
 
 ## The team
 
@@ -20,11 +26,11 @@ areas of the business.
 ## What you will do
 
 - You will be hands-on writing clean and maintainable code.
-- When you have developed something, you will know how to (and you will want to) deploy it to a production environment
-- As a developer, you will mentor other team members, and they will have you as a reference and someone to learn
-  from.
-- You will lead architectural decisions, communicates them, and help teams to adopt the decisions.
 - You will design and implement scalable, performant, and visually stunning web applications that meet user needs.
+- When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
+- As a senior developer, you will mentor other team members, and they will have you as a reference and someone to learn
+  from.
+- You will lead architectural decisions, communicate them, and help teams to adopt them.
 
 ### In one month
 
@@ -52,8 +58,8 @@ areas of the business.
 
 ## About you
 
-- You have strong JavaScript programming skills (+7 years at least).
-- You have experience with React and Typescript (+5 years at least).
+- You have deep JavaScript programming skills.
+- You have strong experience with React and Typescript.
 - You can build custom tooling or libs.
 - You have testing experience (Unit and Integration at least).
 - You have excellent verbal and written communication skills, a great teammate with strong analytical, problem solving, debugging, and troubleshooting skills.
@@ -75,5 +81,5 @@ areas of the business.
 Join us in building something extraordinary. [Apply](https://jobs.holded.com/o/sr-frontend-engineer/c/new) today and let's shape the future of invoicing together!
 
 <p align="center">
-  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/tech-lead.png?id=tech-lead.md" title="logo">
+  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/senior-frontend-engineer.png?id=senior-frontend-engineer.md" title="logo">
 </p>

--- a/openings/senior-fullstack-engineer.md
+++ b/openings/senior-fullstack-engineer.md
@@ -14,7 +14,7 @@ features can be related to one (or more) of our verticals: Accounting, Invoicing
 Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
 performance of the product, creating a safe and fair experience for all our clients.
 
-Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/).
 
 ## The team
 
@@ -27,15 +27,15 @@ areas of the business.
 ## What you will do
 
 - You will be hands-on writing clean and maintainable code across the stack, with a primary focus on the backend.
-- You will design scalable, performant and reliable services and APIs.
 - You will design domain-driven systems combining strategic and tactical design (DDD).
+- You will design scalable, performant and reliable services and APIs.
 - You will actively integrate and experiment with AI capabilities (LLMs and AI-assisted features) as part of the product.
 - You will practice DevOps, you will help to maintain the infrastructure and development environments needed for your
   product area.
 - When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
 - As a senior developer, you will mentor other team members, and they will have you as a reference and someone to learn
   from.
-- You will lead architectural decisions, communicates them, and help teams to adopt the decisions.
+- You will lead architectural decisions, communicate them, and help teams to adopt them.
 - You will collaborate with hiring and training technical personnel.
 
 ### In one month
@@ -60,21 +60,21 @@ areas of the business.
 
 - You will have become a reference within the team, specially in the squad product areas.
 - Your collaborations and your work will have helped to greatly improve the product and team the development experience.
+- You will take initiative in learning about our product, understanding real-world cases, building them into our product, and delivering value to our users.
 
 ## About you
 
 - You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems.
-- You have a solid backend development background, with strong PHP skills (+5 years at least) and deep knowledge of its
-  modern ecosystem.
+- You have a deep backend development background, with strong PHP skills and deep knowledge of its modern ecosystem.
 - You actively use AI tooling (Claude Code, LLMs, or similar) as a natural part of your engineering workflow.
 - You have experience with React and Typescript on the frontend side.
-- You care about best practices and software maintainability is a top priority for you.
-- You feel comfortable working with data structures and algorithms.
-- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc..
 - You have experience using design patterns like DDD.
+- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc...
 - You have testing experience (Unit and Integration at least).
 - You have excellent verbal and written communication skills, a great teammate with strong analytical, problem solving,
   debugging, and troubleshooting skills.
+- You care about best practices and software maintainability is a top priority for you.
+- You feel comfortable working with data structures and algorithms.
 - You like to explore new technologies and are curious about how things work.
 - You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
 - You are proactive and enjoy taking ownership of complex challenges, driving them to resolution.

--- a/openings/senior-fullstack-engineer.md
+++ b/openings/senior-fullstack-engineer.md
@@ -1,0 +1,95 @@
+# Senior Fullstack Engineer
+
+[Apply now!](https://jobs.holded.com/o/sr-fullstack-engineer)
+
+## The role
+
+We are hiring a **Senior Fullstack Engineer** with strong backend expertise and a genuine passion for AI. You will own
+features end-to-end, but you will excel on the server side: architecture, data, performance, and reliability. You will
+also bring hands-on experience with AI tools that are reshaping how software is built today.
+
+Our main product work happens inside cross-disciplinary teams, that we call squads. Each squad is responsible for
+designing, developing, and operating all services relating to the assigned features, inside the Holded platform. The
+features can be related to one (or more) of our verticals: Accounting, Invoicing, Team Management, Project Management,
+Inventory, CRM, etc... The goal is to build a strong and reliable platform, keeping in mind the scalability and
+performance of the product, creating a safe and fair experience for all our clients.
+
+Read about other perks and benefits at [jobs.holded.com](https://jobs.holded.com/)
+
+## The team
+
+You will be part of a product development cross-functional team, where you will work with other backend, frontend and
+full-stack developers, product owners, etc... building and epic digital product.
+
+The teams are empowered to make independent decisions, partnering effectively with the product, analytics, and other
+areas of the business.
+
+## What you will do
+
+- You will be hands-on writing clean and maintainable code across the stack, with a primary focus on the backend.
+- You will design scalable, performant and reliable services and APIs.
+- You will design domain-driven systems combining strategic and tactical design (DDD).
+- You will actively integrate and experiment with AI capabilities (LLMs and AI-assisted features) as part of the product.
+- You will practice DevOps, you will help to maintain the infrastructure and development environments needed for your
+  product area.
+- When you have developed something, you will know how to (and you will want to) deploy it to a production environment.
+- As a senior developer, you will mentor other team members, and they will have you as a reference and someone to learn
+  from.
+- You will lead architectural decisions, communicates them, and help teams to adopt the decisions.
+- You will collaborate with hiring and training technical personnel.
+
+### In one month
+
+- You will have completed your onboarding.
+- You will already know the whole team.
+- You will have deployed several times to production.
+- You will have joined the main architectural discussions that will be taking place and have actively participated in
+  them.
+- You will know the main product areas of your squad, and you already know how to ask when you have any product-related
+  question.
+
+### In three months
+
+- You will already know all the processes and tools in depth.
+- You will know the architecture in detail, and you will be in the process of improving certain parts. By then, you will
+  have clear areas you would like to improve and lead the adoption of those improvements.
+- You will have participated in a successful project, be it a product feature, a technical debt reduction, a DX
+  improvement, etc... achieving the expected result and with total technical independence.
+
+### In six months
+
+- You will have become a reference within the team, specially in the squad product areas.
+- Your collaborations and your work will have helped to greatly improve the product and team the development experience.
+
+## About you
+
+- You have an intrinsic bias towards simplicity and a constant willing to simplify complex systems.
+- You have a solid backend development background, with strong PHP skills (+5 years at least) and deep knowledge of its
+  modern ecosystem.
+- You actively use AI tooling (Claude Code, LLMs, or similar) as a natural part of your engineering workflow.
+- You have experience with React and Typescript on the frontend side.
+- You care about best practices and software maintainability is a top priority for you.
+- You feel comfortable working with data structures and algorithms.
+- You have experience with NoSQL databases (like MongoDB, DynamoDB, Redis), etc..
+- You have experience using design patterns like DDD.
+- You have testing experience (Unit and Integration at least).
+- You have excellent verbal and written communication skills, a great teammate with strong analytical, problem solving,
+  debugging, and troubleshooting skills.
+- You like to explore new technologies and are curious about how things work.
+- You know what is a Git rebase, and you are comfortable working in a large codebase with multiple team members.
+- You are proactive and enjoy taking ownership of complex challenges, driving them to resolution.
+
+## Nice-to-haves
+
+- You have experience integrating AI/ML APIs or LLMs into production systems.
+- You have experience with vector databases or RAG architectures.
+- You practice DevOps, you have experience with infrastructure management, Docker, etc...
+- You have experience designing public APIs (REST, gRPC, etc... ).
+- But the most important is, you are a freak like we are, you love what you do and you want to enjoy your work while
+  building something important.
+
+[Apply now!](https://jobs.holded.com/o/sr-fullstack-engineer)
+
+<p align="center">
+  <img src="https://europe-west1-holded-analytics-dev-208b.cloudfunctions.net/image_tracker/senior-fullstack-engineer.png?id=senior-fullstack-engineer.md" title="logo">
+</p>


### PR DESCRIPTION
## Summary
- Add `openings/fullstack-engineer.md` and `openings/senior-fullstack-engineer.md` for the (Senior) Fullstack Engineer positions.
- Align the 6 FE/BE/FS engineering openings (junior + senior) to share structure, tone, and a consistent junior→senior gradient.